### PR TITLE
Add brush size and save options

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -32,7 +32,7 @@ function stop() {
 
 function draw(event) {
   ctx.beginPath();
-  ctx.lineWidth = 5;
+  ctx.lineWidth = currentBrushSize;
   ctx.lineCap = "round";
   ctx.strokeStyle = currentColor;
   ctx.moveTo(coord.x, coord.y);
@@ -44,8 +44,12 @@ function draw(event) {
 
 // Find buttons and color input
 const clearCanvas = document.getElementById("clearCanvas")
+const saveCanvas = document.getElementById("saveCanvas")
 const colorPicker = document.getElementById("colorPicker")
+const brushSize = document.getElementById("brushSize")
+const brushSizeValue = document.getElementById("brushSizeValue")
 let currentColor = "#FF6D60"
+let currentBrushSize = 5
 
 
 colorPicker.addEventListener("input", function(){
@@ -54,6 +58,21 @@ colorPicker.addEventListener("input", function(){
 
   // Change buttons color
   clearCanvas.style.background = currentColor
+  saveCanvas.style.background = currentColor
+})
+
+// Change brush size
+brushSize.addEventListener("input", function(){
+  currentBrushSize = parseInt(this.value)
+  brushSizeValue.textContent = currentBrushSize
+})
+
+// Save canvas as image
+saveCanvas.addEventListener("click", function(){
+  const link = document.createElement('a');
+  link.download = 'drawing.png';
+  link.href = canvas.toDataURL();
+  link.click();
 })
 
 

--- a/index.html
+++ b/index.html
@@ -24,8 +24,15 @@
     <!-- Color picker -->
     <input type="color" id="colorPicker" value="#FF6D60">
 
+    <!-- Brush size slider -->
+    <input type="range" id="brushSize" min="1" max="50" value="5">
+    <span id="brushSizeValue">5</span>
+
     <!-- Clear canvas -->
     <button id="clearCanvas"><i class="fa-solid fa-trash"></i></button>
+
+    <!-- Save canvas -->
+    <button id="saveCanvas"><i class="fa-solid fa-download"></i></button>
   </div>
 
 

--- a/style.css
+++ b/style.css
@@ -60,3 +60,12 @@ canvas {
 .commands button:hover {
     transform: scale(1.1);
 }
+
+#brushSize {
+    width: 100px;
+}
+
+#brushSizeValue {
+    color: white;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add slider to control brush size and button to save the canvas
- show current brush size value and style slider
- allow dynamic brush size and exporting the drawing from JS

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68891aecf72883288993436059c9a3ab