### PR TITLE
Add brush size and image download options

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -32,7 +32,7 @@ function stop() {
 
 function draw(event) {
   ctx.beginPath();
-  ctx.lineWidth = 5;
+  ctx.lineWidth = currentSize;
   ctx.lineCap = "round";
   ctx.strokeStyle = currentColor;
   ctx.moveTo(coord.x, coord.y);
@@ -45,7 +45,10 @@ function draw(event) {
 // Find buttons and color input
 const clearCanvas = document.getElementById("clearCanvas")
 const colorPicker = document.getElementById("colorPicker")
+const brushSize = document.getElementById("brushSize")
+const saveCanvas = document.getElementById("saveCanvas")
 let currentColor = "#FF6D60"
+let currentSize = 5
 
 
 colorPicker.addEventListener("input", function(){
@@ -54,6 +57,18 @@ colorPicker.addEventListener("input", function(){
 
   // Change buttons color
   clearCanvas.style.background = currentColor
+  saveCanvas.style.background = currentColor
+})
+
+brushSize.addEventListener("input", function(){
+  currentSize = this.value
+})
+
+saveCanvas.addEventListener("click", function(){
+  const link = document.createElement("a")
+  link.download = "canvas.png"
+  link.href = canvas.toDataURL()
+  link.click()
 })
 
 

--- a/index.html
+++ b/index.html
@@ -24,8 +24,14 @@
     <!-- Color picker -->
     <input type="color" id="colorPicker" value="#FF6D60">
 
+    <!-- Brush size -->
+    <input type="range" id="brushSize" min="1" max="50" value="5">
+
     <!-- Clear canvas -->
     <button id="clearCanvas"><i class="fa-solid fa-trash"></i></button>
+
+    <!-- Save image -->
+    <button id="saveCanvas"><i class="fa-solid fa-download"></i></button>
   </div>
 
 

--- a/style.css
+++ b/style.css
@@ -57,6 +57,10 @@ canvas {
     color: white;
 }
 
+#brushSize {
+    width: 100px;
+}
+
 .commands button:hover {
     transform: scale(1.1);
 }


### PR DESCRIPTION
## Summary
- add brush size slider and download button to the UI
- style the new input
- support variable brush size and saving the canvas as an image

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68891aecf72883288993436059c9a3ab